### PR TITLE
Example of serving static content under "/" path.

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="src" output="target/classes" path="src/main/java">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry excluding="**" kind="src" output="target/classes" path="src/main/resources">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" output="target/test-classes" path="src/test/java">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="output" path="target/classes"/>
+</classpath>

--- a/.project
+++ b/.project
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>dropwizard-swagger-sample-app</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+	</natures>
+</projectDescription>

--- a/.settings/org.eclipse.jdt.core.prefs
+++ b/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,5 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.7
+org.eclipse.jdt.core.compiler.compliance=1.7
+org.eclipse.jdt.core.compiler.problem.forbiddenReference=warning
+org.eclipse.jdt.core.compiler.source=1.7

--- a/.settings/org.eclipse.m2e.core.prefs
+++ b/.settings/org.eclipse.m2e.core.prefs
@@ -1,0 +1,4 @@
+activeProfiles=
+eclipse.preferences.version=1
+resolveWorkspaceProjects=true
+version=1

--- a/README.md
+++ b/README.md
@@ -19,13 +19,25 @@ How to run it (command line)
 
 Sample URLs
 -----------
+Administrative URLs
+
 * [http://localhost:9999/admin](http://localhost:9999/admin)
+
+
+Application URLs
 
 * [http://localhost:9999/api/sample](http://localhost:9999/api/sample)
 * [http://localhost:9999/api/sample/hello-with-path-param/First Last](http://localhost:9999/api/sample/hello-with-path-param/First Last)
 * [http://localhost:9999/api/sample/hello-with-query-param?name=First Last](http://localhost:9999/api/sample/hello-with-query-param?name=First Last)
-* [http://localhost:9999/api/swagger](http://localhost:9999/api/swagger)
 
+
+SWAGGER URLs
+
+* [http://localhost:9999/api/swagger](http://localhost:9999/api/swagger) -- SWAGGER is not working when there is static content returned under "/"! User will be able to see API access points but will NOT be able to invoke them with SWAGGER! User MUST enter manually value of `base url`: http://localhost:9999/api/api-docs
+
+
+Static URLs(.html and .txt files)
 
 * [http://localhost:9999/](http://localhost:9999/)
+* [http://localhost:9999/index.html](http://localhost:9999/index.html)
 * [http://localhost:9999/assets/sample-file.txt](http://localhost:9999/assets/sample-file.txt)

--- a/README.md
+++ b/README.md
@@ -15,3 +15,17 @@ How to run it (command line)
 * `mvn clean package`
 * `java -jar target/dropwizard-swagger-sample-app-1.0-SNAPSHOT.jar server src/main/resources/sample-config.yaml`
 * Open your browser and hit http://localhost:9999/swagger
+
+
+Sample URLs
+-----------
+* [http://localhost:9999/admin](http://localhost:9999/admin)
+
+* [http://localhost:9999/api/sample](http://localhost:9999/api/sample)
+* [http://localhost:9999/api/sample/hello-with-path-param/First Last](http://localhost:9999/api/sample/hello-with-path-param/First Last)
+* [http://localhost:9999/api/sample/hello-with-query-param?name=First Last](http://localhost:9999/api/sample/hello-with-query-param?name=First Last)
+* [http://localhost:9999/api/swagger](http://localhost:9999/api/swagger)
+
+
+* [http://localhost:9999/](http://localhost:9999/)
+* [http://localhost:9999/assets/sample-file.txt](http://localhost:9999/assets/sample-file.txt)

--- a/SampleApplication-2.launch
+++ b/SampleApplication-2.launch
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<launchConfiguration type="org.eclipse.jdt.launching.localJavaApplication">
+<listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
+<listEntry value="/dropwizard-swagger-sample-app/src/main/java/io/federecio/dropwizard/swagger/sample/SampleApplication.java"/>
+</listAttribute>
+<listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
+<listEntry value="1"/>
+</listAttribute>
+<listAttribute key="org.eclipse.debug.ui.favoriteGroups">
+<listEntry value="org.eclipse.debug.ui.launchGroup.run"/>
+</listAttribute>
+<stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="io.federecio.dropwizard.swagger.sample.SampleApplication"/>
+<stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="server src/main/resources/sample-config-2.yaml"/>
+<stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="dropwizard-swagger-sample-app"/>
+</launchConfiguration>

--- a/SampleApplication.launch
+++ b/SampleApplication.launch
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<launchConfiguration type="org.eclipse.jdt.launching.localJavaApplication">
+<listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
+<listEntry value="/dropwizard-swagger-sample-app/src/main/java/io/federecio/dropwizard/swagger/sample/SampleApplication.java"/>
+</listAttribute>
+<listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
+<listEntry value="1"/>
+</listAttribute>
+<listAttribute key="org.eclipse.debug.ui.favoriteGroups">
+<listEntry value="org.eclipse.debug.ui.launchGroup.run"/>
+</listAttribute>
+<stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="io.federecio.dropwizard.swagger.sample.SampleApplication"/>
+<stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="server src/main/resources/sample-config.yaml"/>
+<stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="dropwizard-swagger-sample-app"/>
+</launchConfiguration>

--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,20 @@
         </dependency>
     </dependencies>
 
+		<repositories>
+			<repository>
+				<id>sonatype-nexus-snapshots</id>
+				<name>Sonatype Nexus Snapshots</name>
+				<url>https://oss.sonatype.org/content/repositories/snapshots</url>
+				<releases>
+					<enabled>false</enabled>
+				</releases>
+				<snapshots>
+					<enabled>true</enabled>
+				</snapshots>
+			</repository>
+		</repositories>
+
     <build>
         <plugins>
             <plugin>
@@ -57,10 +71,8 @@
                         </goals>
                         <configuration>
                             <transformers>
-                                <transformer
-                                        implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
-                                <transformer
-                                        implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                                     <mainClass>io.federecio.dropwizard.swagger.sample.SampleApplication</mainClass>
                                 </transformer>
                             </transformers>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,8 @@
         <dependency>
             <groupId>io.federecio</groupId>
             <artifactId>dropwizard-swagger</artifactId>
-            <version>0.5.3</version>
+            <!--version>0.5.3</version-->
+            <version>0.5.4-SNAPSHOT</version>
         </dependency>
     </dependencies>
 

--- a/src/main/java/io/federecio/dropwizard/swagger/sample/SampleApplication.java
+++ b/src/main/java/io/federecio/dropwizard/swagger/sample/SampleApplication.java
@@ -1,29 +1,39 @@
 package io.federecio.dropwizard.swagger.sample;
 
 import io.dropwizard.Application;
+import io.dropwizard.assets.AssetsBundle;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
 import io.federecio.dropwizard.swagger.SwaggerDropwizard;
 
 /**
  * @author Federico Recio
+ * @author Trifon Trifonov
  */
 public class SampleApplication extends Application<SampleConfiguration> {
 
-    private final SwaggerDropwizard swaggerDropwizard = new SwaggerDropwizard();
+	private final SwaggerDropwizard<SampleConfiguration> swaggerDropwizard = new SwaggerDropwizard<SampleConfiguration>();
 
-    public static void main(String...args) throws Exception {
-        new SampleApplication().run(args);
-    }
+	public static void main(String... args) throws Exception {
+		new SampleApplication().run(args);
+	}
 
-    @Override
-    public void initialize(Bootstrap<SampleConfiguration> bootstrap) {
-        swaggerDropwizard.onInitialize(bootstrap);
-    }
+	@Override
+	public void initialize(Bootstrap<SampleConfiguration> bootstrap) {
+		swaggerDropwizard.onInitialize(bootstrap);
 
-    @Override
-    public void run(SampleConfiguration configuration, Environment environment) throws Exception {
-        environment.jersey().register(new SampleResource());
-        swaggerDropwizard.onRun(configuration, environment, "localhost");
-    }
+		// Serve anything under /web-assets inside my JAR file under the URL pattern /,
+		// with "index.html" as the default file. This bundle will be named "static-bundle", but name can be changed to whatever name you like.
+		bootstrap.addBundle(new AssetsBundle("/web-assets", "/", "index.html", "static-bundle"));    // In order to work properly: environment.jersey().setUrlPattern("/api/*");
+	}
+
+	@Override
+	public void run(SampleConfiguration configuration, Environment environment) throws Exception {
+		//   Asset bundles not able to be served from root path.
+		// - https://github.com/dropwizard/dropwizard/issues/661
+		environment.jersey().setUrlPattern( "/api/*" );
+
+		environment.jersey().register(new SampleResource());
+		swaggerDropwizard.onRun(configuration, environment, "localhost");
+	}
 }

--- a/src/main/java/io/federecio/dropwizard/swagger/sample/SampleResource.java
+++ b/src/main/java/io/federecio/dropwizard/swagger/sample/SampleResource.java
@@ -13,6 +13,7 @@ import javax.ws.rs.core.Response;
  */
 @Path("/sample")
 @Api("/sample")
+@Produces(MediaType.APPLICATION_JSON)
 public class SampleResource {
 
     @GET

--- a/src/main/resources/sample-config-2.yaml
+++ b/src/main/resources/sample-config-2.yaml
@@ -1,0 +1,8 @@
+server:
+  type: simple
+  applicationContextPath: /app
+  adminContextPath: /admin
+  connector:
+    type: http
+    port: 9999
+name: test app

--- a/src/main/resources/web-assets/assets/sample-file.txt
+++ b/src/main/resources/web-assets/assets/sample-file.txt
@@ -1,0 +1,1 @@
+Sample content.

--- a/src/main/resources/web-assets/index.html
+++ b/src/main/resources/web-assets/index.html
@@ -1,0 +1,3 @@
+<html>
+<body>Hello Trifon</body>
+</html>


### PR DESCRIPTION
Hi Federico Recio,

first of all thank you very much for the GREAT module "dropwizard-swagger"! I like your module very much!
Keep the good work!

I have extended dropwizard-swagger-sample-app and I have added static content mapped under "/" path.
This is in order to demonstrate exisitng bug(https://github.com/federecio/dropwizard-swagger/issues/32) in dropwizard-swagger module.
I have a fix for this bug and will uppload it soon.

Kind regards,
Trifon
